### PR TITLE
Add versioning information to git repos

### DIFF
--- a/roles/ansible-role-pidev/defaults/main.yml
+++ b/roles/ansible-role-pidev/defaults/main.yml
@@ -18,13 +18,18 @@ pidev_docker_images:
 pidev_piedpiper_cli:
   - name: piedpiper-picli
     org_name: afcyber-dream 
+    version: master
 
 pidev_piedpiper_faas:
   - name: piedpiper-validator-faas
     org_name: afcyber-dream 
+    version: master
   - name: piedpiper-cpplint-faas
     org_name: afcyber-dream 
+    version: master
   - name: piedpiper-flake8-faas
     org_name: afcyber-dream 
+    version: master
   - name: piedpiper-pylint-faas
     org_name: afcyber-dream 
+    version: master

--- a/roles/ansible-role-pidev/tasks/piedpiper_cli.yml
+++ b/roles/ansible-role-pidev/tasks/piedpiper_cli.yml
@@ -7,6 +7,7 @@
         repo: "https://github.com/{{ item.org_name }}/{{ item.name }}.git"
         dest: "{{ pidev_user.homedir }}/{{ item.org_name }}/{{ item.name }}/"
         clone: "yes"
+        version: "{{ item.version | default(omit) }}"
         force: "yes"
       with_items:
         - "{{ pidev_piedpiper_cli }}"

--- a/roles/ansible-role-pidev/tasks/piedpiper_faas.yml
+++ b/roles/ansible-role-pidev/tasks/piedpiper_faas.yml
@@ -6,6 +6,7 @@
       git:
         repo: "https://github.com/{{ item.org_name }}/{{ item.name }}.git"
         dest: "{{ pidev_user.homedir }}/{{ item.org_name }}/{{ item.name }}/"
+        version: "{{ item.version | default(omit) }}"
         clone: "yes"
         force: "yes"
       with_items:


### PR DESCRIPTION
Allows the user to specify specific versions of the Git
repositories defined in defaults/main.yml. These versions can be
any identifier that Git will consume.
See https://docs.ansible.com/ansible/latest/modules/git_module.html