### PR TITLE
Add dockerfile to terraform and modified instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This environment is used to test faas integration with `openfaas cloud` installe
 
 ### Environment Provisioning
 
-Two supported options push with terraform or pull with a bootstra.sh script.
+Two supported options push with terraform or pull with the bootstrap.sh script.
 
 push is good for dev or managing infra with terraform, pull is good for CI/CD and docker image builds etc.
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,18 @@ rerun this command to reinitialize your working directory. If you forget, other
 commands will detect it and remind you to do so if necessary.
 ```
 
+###### Run Docker container to run Terraform
+
+If, instead, you want to run Terraform within a container, do the following:
+
+`docker build -t ubuntu1804/pidev-terraform terraform/`
+
+`docker run -v $(pwd):/code -it ubuntu1804/pidev-terraform /bin/bash`
+
+You will now be able to do everything from the mounted /code directory.
+
+You might also need to mount the ssh keys for Digital Ocean by adding `-v [insert-ssh-key-dir]:/.ssh` to the run command
+
 ###### Run Terraform
 From `terraform/` run `terraform apply`
 

--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:18.04
+
+ENV TF_VERSION 0.11.13
+ENV TF_ANSIBLE_VERSION 2.2.0
+
+RUN apt-get update && apt-get install -y curl git python3 python3-pip unzip
+
+RUN pip3 install ansible==2.7
+
+# Install Terraform
+RUN curl https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip -o \
+                                                          terraform_${TF_VERSION}.zip
+RUN unzip terraform_${TF_VERSION}.zip
+RUN mv terraform /usr/bin/terraform
+
+# Install Terraform-Ansible
+RUN git clone https://github.com/AFCYBER-DREAM/ansible-collection-pidev.git
+RUN sed -i -e '1s/sh/bash/' ansible-collection-pidev/terraform/install-tf-ansible.sh
+
+RUN ./ansible-collection-pidev/terraform/install-tf-ansible.sh -v ${TF_ANSIBLE_VERSION}
+
+# Cleanup
+RUN rm -r ansible-collection-pidev && rm terraform_${TF_VERSION}.zip
+


### PR DESCRIPTION
Dockerfile for Ubuntu 18.04 locking terraform to v0.11.13 and ansible_terraform_provisioner to v2.2.0 (per instructions in build-openfaas-digitalocean.tf)